### PR TITLE
Minor updates for compound type view

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -844,6 +844,7 @@ class _Plot2dRecordView(DataView):
         self._data = None
         self._xAxisDropDown = None
         self._yAxisDropDown = None
+        self.__fields = None
 
     def createWidget(self, parent):
         from silx.gui import plot
@@ -863,17 +864,23 @@ class _Plot2dRecordView(DataView):
 
         all_fields = sorted(self._data.dtype.fields.items(), key=lambda e: e[1][1])
         numeric_fields = [f[0] for f in all_fields if numpy.issubdtype(f[1][0], numpy.number)]
-        self.getWidget().setSelectableXAxisFieldNames(numeric_fields)
-        self.getWidget().setSelectableYAxisFieldNames(numeric_fields)
-        fieldNameX = numeric_fields[0]
-        fieldNameY = numeric_fields[1]
+        if numeric_fields == self.__fields:  # Reuse previously selected fields
+            fieldNameX = self.getWidget().getXAxisFieldName()
+            fieldNameY = self.getWidget().getYAxisFieldName()
+        else:
+            self.__fields = numeric_fields
 
-        # If there is a field called time, use it for the x-axis by default
-        if "time" in numeric_fields:
-            fieldNameX = "time"
-        # Use the first field that is not "time" for the y-axis
-        if fieldNameY == "time":
-            fieldNameY = numeric_fields[0]
+            self.getWidget().setSelectableXAxisFieldNames(numeric_fields)
+            self.getWidget().setSelectableYAxisFieldNames(numeric_fields)
+            fieldNameX = numeric_fields[0]
+            fieldNameY = numeric_fields[1]
+
+            # If there is a field called time, use it for the x-axis by default
+            if "time" in numeric_fields:
+                fieldNameX = "time"
+            # Use the first field that is not "time" for the y-axis
+            if fieldNameY == "time":
+                fieldNameY = numeric_fields[0]
 
         self._plotData(fieldNameX, fieldNameY)
 

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -870,7 +870,7 @@ class _Plot2dRecordView(DataView):
         else:
             self.__fields = numeric_fields
 
-            self.getWidget().setSelectableXAxisFieldNames(numeric_fields)
+            self.getWidget().setSelectableXAxisFieldNames(['-'] + numeric_fields)
             self.getWidget().setSelectableYAxisFieldNames(numeric_fields)
             fieldNameX = numeric_fields[0]
             fieldNameY = numeric_fields[1]
@@ -895,9 +895,14 @@ class _Plot2dRecordView(DataView):
 
     def _plotData(self, fieldNameX, fieldNameY):
         self.clear()
+        ydata = self._data[fieldNameY]
+        if fieldNameX == '-':
+            xdata = numpy.arange(len(ydata))
+        else:
+            xdata = self._data[fieldNameX]
         self.getWidget().addCurve(legend="data",
-                                  x=self._data[fieldNameX],
-                                  y=self._data[fieldNameY],
+                                  x=xdata,
+                                  y=ydata,
                                   resetzoom=self.__resetZoomNextTime)
         self.getWidget().setXAxisFieldName(fieldNameX)
         self.getWidget().setYAxisFieldName(fieldNameY)

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -897,7 +897,7 @@ class _Plot2dRecordView(DataView):
         self.__resetZoomNextTime = True
 
     def axesNames(self, data, info):
-        return ["y"]
+        return ["data"]
 
     def getDataPriority(self, data, info):
         if info.size <= 0:

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -872,7 +872,7 @@ class _Plot2dRecordView(DataView):
 
             self.getWidget().setSelectableXAxisFieldNames(['-'] + numeric_fields)
             self.getWidget().setSelectableYAxisFieldNames(numeric_fields)
-            fieldNameX = numeric_fields[0]
+            fieldNameX = '-'
             fieldNameY = numeric_fields[1]
 
             # If there is a field called time, use it for the x-axis by default

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -870,17 +870,17 @@ class _Plot2dRecordView(DataView):
         else:
             self.__fields = numeric_fields
 
-            self.getWidget().setSelectableXAxisFieldNames(['-'] + numeric_fields)
+            self.getWidget().setSelectableXAxisFieldNames(numeric_fields)
             self.getWidget().setSelectableYAxisFieldNames(numeric_fields)
-            fieldNameX = '-'
-            fieldNameY = numeric_fields[1]
+            fieldNameX = None
+            fieldNameY = numeric_fields[0]
 
             # If there is a field called time, use it for the x-axis by default
             if "time" in numeric_fields:
                 fieldNameX = "time"
             # Use the first field that is not "time" for the y-axis
-            if fieldNameY == "time":
-                fieldNameY = numeric_fields[0]
+            if fieldNameY == "time" and len(numeric_fields) >= 2:
+                fieldNameY = numeric_fields[1]
 
         self._plotData(fieldNameX, fieldNameY)
 
@@ -891,12 +891,13 @@ class _Plot2dRecordView(DataView):
             self._yAxisDropDown.activated.connect(self._onAxesSelectionChaned)
 
     def _onAxesSelectionChaned(self):
-        self._plotData(self._xAxisDropDown.currentText(), self._yAxisDropDown.currentText())
+        fieldNameX = self._xAxisDropDown.currentData()
+        self._plotData(fieldNameX, self._yAxisDropDown.currentText())
 
     def _plotData(self, fieldNameX, fieldNameY):
         self.clear()
         ydata = self._data[fieldNameY]
-        if fieldNameX == '-':
+        if fieldNameX is None:
             xdata = numpy.arange(len(ydata))
         else:
             xdata = self._data[fieldNameX]

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -817,16 +817,26 @@ class RecordPlot(PlotWindow):
         if parent is None:
             self.setWindowTitle('RecordPlot')
         self._axesSelectionToolBar = tools.toolbars.AxesSelectionToolBar(parent=self, plot=self)
-        self.addToolBar(self._axesSelectionToolBar)
+        self.addToolBar(qt.Qt.BottomToolBarArea, self._axesSelectionToolBar)
 
     def setXAxisFieldName(self, value):
-        self.getXAxis().setLabel(value)
-        index = self._axesSelectionToolBar.getXAxisDropDown().findText(value)
+        """Set the current selected field for the X axis.
+
+        :param Union[str,None] value:
+        """
+        label = '' if value is None else value
+        index = self._axesSelectionToolBar.getXAxisDropDown().findData(value)
+
         if index >= 0:
+            self.getXAxis().setLabel(label)
             self._axesSelectionToolBar.getXAxisDropDown().setCurrentIndex(index)
 
     def getXAxisFieldName(self):
-        return self._axesSelectionToolBar.getXAxisDropDown().currentText()
+        """Returns currently selected field for the X axis or None.
+
+        rtype: Union[str,None]
+        """
+        return self._axesSelectionToolBar.getXAxisDropDown().currentData()
 
     def setYAxisFieldName(self, value):
         self.getYAxis().setLabel(value)
@@ -838,8 +848,16 @@ class RecordPlot(PlotWindow):
         return self._axesSelectionToolBar.getYAxisDropDown().currentText()
 
     def setSelectableXAxisFieldNames(self, fieldNames):
-        self._axesSelectionToolBar.getXAxisDropDown().clear()
-        self._axesSelectionToolBar.getXAxisDropDown().addItems(fieldNames)
+        """Add list of field names to X axis
+
+        :param List[str] fieldNames:
+        """
+        comboBox = self._axesSelectionToolBar.getXAxisDropDown()
+        comboBox.clear()
+        comboBox.addItem('-', None)
+        comboBox.insertSeparator(1)
+        for name in fieldNames:
+            comboBox.addItem(name, name)
 
     def setSelectableYAxisFieldNames(self, fieldNames):
         self._axesSelectionToolBar.getYAxisDropDown().clear()

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -825,11 +825,17 @@ class RecordPlot(PlotWindow):
         if index >= 0:
             self._axesSelectionToolBar.getXAxisDropDown().setCurrentIndex(index)
 
+    def getXAxisFieldName(self):
+        return self._axesSelectionToolBar.getXAxisDropDown().currentText()
+
     def setYAxisFieldName(self, value):
         self.getYAxis().setLabel(value)
         index = self._axesSelectionToolBar.getYAxisDropDown().findText(value)
         if index >= 0:
             self._axesSelectionToolBar.getYAxisDropDown().setCurrentIndex(index)
+
+    def getYAxisFieldName(self):
+        return self._axesSelectionToolBar.getYAxisDropDown().currentText()
 
     def setSelectableXAxisFieldNames(self, fieldNames):
         self._axesSelectionToolBar.getXAxisDropDown().clear()

--- a/silx/gui/plot/tools/toolbars.py
+++ b/silx/gui/plot/tools/toolbars.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -42,6 +42,8 @@ class AxesSelectionToolBar(qt.QToolBar):
         super(AxesSelectionToolBar, self).__init__(title, parent)
 
         assert isinstance(plot, PlotWidget)
+
+        self.addWidget(qt.QLabel("Field selection: "))
 
         self._labelXAxis = qt.QLabel(" X: ")
         self.addWidget(self._labelXAxis)


### PR DESCRIPTION
This PR proposes:
- To change the name displayed in "Axis selection" to `data` to be consistent with the "Raw" view for N-D compound datasets.
- Avoid resetting fields selection when changing "Axis selection" or changing to a dataset with the same fields.
- Add an option to select no field for "X" and use it as default if no `time` field. What do you think of making it the default?

